### PR TITLE
Added docker compose to spin-up Zipkin and Seq, plus console output

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3'
+services:
+  zipkin:
+    image: "openzipkin/zipkin"
+    ports:
+      - "9411:9411"
+  seq:
+    image: "datalust/seq"
+    ports:
+      - "8080:80"
+      - "5341:5341"
+    environment:
+      - ACCEPT_EULA=Y

--- a/talk2/DistributedTracing/BackEnd/BackEnd.csproj
+++ b/talk2/DistributedTracing/BackEnd/BackEnd.csproj
@@ -11,5 +11,6 @@
     <PackageReference Include="OpenTelemetry.Hosting" Version="0.2.0-alpha.179" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>
 </Project>

--- a/talk2/DistributedTracing/BackEnd/Program.cs
+++ b/talk2/DistributedTracing/BackEnd/Program.cs
@@ -25,6 +25,7 @@ namespace BackEnd
                 .UseSerilog((context, logging) =>
                 {
                     logging.WriteTo.Seq("http://localhost:5341/");
+                    logging.WriteTo.Console();
                 })
                 .ConfigureWebHostDefaults(webBuilder =>
                 {

--- a/talk2/DistributedTracing/FrontEnd/FrontEnd.csproj
+++ b/talk2/DistributedTracing/FrontEnd/FrontEnd.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="OpenTelemetry.Hosting" Version="0.2.0-alpha.179" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.Seq" Version="4.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
   </ItemGroup>
 
 </Project>

--- a/talk2/DistributedTracing/FrontEnd/Program.cs
+++ b/talk2/DistributedTracing/FrontEnd/Program.cs
@@ -25,6 +25,7 @@ namespace FrontEnd
                 .UseSerilog((context, logging)=>
                 {
                     logging.WriteTo.Seq("http://localhost:5341/");
+                    logging.WriteTo.Console();
                 })
                 .ConfigureWebHostDefaults(webBuilder =>
                 {


### PR DESCRIPTION
Hi David,

not sure if this could be useful for you or anyone which easily want to spin-up the 2nd demo.

The console output is for ease of debugging startup issues.